### PR TITLE
use out-most `::String` class when return strings

### DIFF
--- a/src/g_i_repository/info/type_info.cr
+++ b/src/g_i_repository/info/type_info.cr
@@ -103,7 +103,7 @@ module GIRepository
           variable
         end
       when LibGIRepository::TypeTag::UTF8, LibGIRepository::TypeTag::FILENAME
-        %((raise "Expected string but got null" unless #{variable}; String.new(#{variable})))
+        %((raise "Expected string but got null" unless #{variable}; ::String.new(#{variable})))
       else
         variable
       end


### PR DESCRIPTION
this allows wrapped namespaces to define `String` as internal class