### PR TITLE
Fix autorun

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -4,7 +4,7 @@ authors:
   - "Jonne Haß <me@jhass.eu>"
 description: "GObject introspection based binding generator and generated bindings"
 license: Apache-2.0
-crystal: 0.23.1
+crystal: 0.24.2
 targets:
   generator:
     main: src/generator/stage3.cr

--- a/src/gtk/autorun.cr
+++ b/src/gtk/autorun.cr
@@ -1,11 +1,13 @@
 require "./gtk"
 
-redefine_main do |main|
-  LibGtk.init pointerof(ARGC_UNSAFE), pointerof(ARGV_UNSAFE)
+fun main(argc: Int32, argv : UInt8**) : Int32
+  Crystal.main do
+    LibGtk.init pointerof(ARGC_UNSAFE), pointerof(ARGV_UNSAFE)
 
-  {{main}}
+    Crystal.main_user_code(argc, argv)
 
-  LibGtk.main
+    LibGtk.main
+  end
 end
 
 Signal::INT.trap do


### PR DESCRIPTION
`redefine_main` no longer exists.

See https://github.com/crystal-lang/crystal/pull/4998