### PR TITLE
avoid having to redefine 'new' constructors when overloading initialize

### DIFF
--- a/samples/gtk_subclasses.cr
+++ b/samples/gtk_subclasses.cr
@@ -1,33 +1,21 @@
 require "../src/gtk"
 
 class MyWindow < Gtk::ApplicationWindow
-  def self.new(app : Gtk::Application)
-    super
-  end
-
-  def initialize(ptr)
-    super(ptr)
-
+  construct {
     self.border_width = 10
     self.title = "Hello"
     add Gtk::Label.new("Hello")
-  end
+  }
 end
 
 class MyApp < Gtk::Application
-  def self.new(id, flags : Gio::ApplicationFlags)
-    super
-  end
-
-  def initialize(ptr)
-    super(ptr)
-
+  construct {
     on_activate do |application|
       window = MyWindow.new(self)
       window.connect "destroy", &->quit
       window.show_all
     end
-  end
+  }
 end
 
 app = MyApp.new("org.crystal.mysample", :flags_none)

--- a/src/g_i_repository/info/function_info.cr
+++ b/src/g_i_repository/info/function_info.cr
@@ -60,8 +60,10 @@ module GIRepository
         io << "\n#{indent}  GLib::Error.assert __error" if throws?
 
         unless skip_return?
-          io << "\n#{indent}  #{"cast " if constructor?}#{return_type.convert_to_crystal("__return_value")}"
+          io << "\n#{indent}  #{"ins = " if constructor?}#{"cast " if constructor?}#{return_type.convert_to_crystal("__return_value")}"
           io << " if __return_value" if may_return_null?
+          io << "\n#{indent}  ins.construct" if constructor?
+          io << "\n#{indent}  ins" if constructor?  
           io << '\n'
         else
           io << "\n#{indent}  nil\n"

--- a/src/g_object/wrapped_type.cr
+++ b/src/g_object/wrapped_type.cr
@@ -1,5 +1,14 @@
 module GObject
   module WrappedType
+    def construct()
+    end
+
+    macro construct(&b)
+      def construct
+        {{b.body}}
+      end
+    end
+  
     macro def_cast(libtype)
       {% if libtype.resolve? %}
         def self.cast(object) : self


### PR DESCRIPTION
an after initialize hook, not applicable to `cast`  
the macro makes it look less artificial :D (crystal should have this built in :/)

```ruby
class Mine < Some::GObject
  construct {
    # called after initialize
  }

  ## or
  # def construct
  #   # ...
  # end
end
```