### PR TITLE
Fix generating invalid structs when fields are upcased

### DIFF
--- a/src/g_i_repository/info/arg_info.cr
+++ b/src/g_i_repository/info/arg_info.cr
@@ -6,6 +6,7 @@ module GIRepository
 
     def name
       name = super
+      name = "_#{name}" if name == name.upcase if name
       name = "_#{name}" if KEYWORDS.includes? name
       name.gsub(/_+$/, "") if name
     end

--- a/src/g_i_repository/info/arg_info.cr
+++ b/src/g_i_repository/info/arg_info.cr
@@ -6,7 +6,7 @@ module GIRepository
 
     def name
       name = super
-      name = "_#{name}" if name == name.upcase if name
+      name = "_#{name}" if name[0].uppercase? if name
       name = "_#{name}" if KEYWORDS.includes? name
       name.gsub(/_+$/, "") if name
     end

--- a/src/g_i_repository/info/field_info.cr
+++ b/src/g_i_repository/info/field_info.cr
@@ -10,6 +10,7 @@ module GIRepository
 
     def name(keyword_safe=true)
       name = super()
+      name = "_#{name}" if name == name.upcase if name
       name += '_' if keyword_safe && KEYWORDS.includes? name if name
       name
     end

--- a/src/g_i_repository/info/field_info.cr
+++ b/src/g_i_repository/info/field_info.cr
@@ -10,7 +10,7 @@ module GIRepository
 
     def name(keyword_safe=true)
       name = super()
-      name = "_#{name}" if name == name.upcase if name
+      name = "_#{name}" if name[0].uppercase? if name
       name += '_' if keyword_safe && KEYWORDS.includes? name if name
       name
     end


### PR DESCRIPTION
Example (Granite-1.0.gir):
```xml
...
<class name="DrawingColor" c:type="GraniteDrawingColor" glib:type-name="GraniteDrawingColor" glib:get-type="granite_drawing_color_get_type" g
lib:type-struct="DrawingColorClass" parent="GObject.Object">
                <implements name="Granite.ServicesSettingsSerializable"/>
                <field name="parent_instance">
                        <type name="GObject.Object" c:type="GObject"/>
                </field>
                <field name="priv">
                        <type name="DrawingColorPrivate" c:type="GraniteDrawingColorPrivate*"/>
                </field>
                <field name="R">
                        <type name="gdouble" c:type="gdouble"/>
                </field>
                <field name="G">
                        <type name="gdouble" c:type="gdouble"/>
                </field>
                <field name="B">
                        <type name="gdouble" c:type="gdouble"/>
                </field>
                <field name="A">
                        <type name="gdouble" c:type="gdouble"/>
                </field>
...
```

Which would generate:

```crystal
...
struct DrawingColor # object
    parent_instance : LibGObject::Object*
    priv : LibGranite::DrawingColorPrivate*
    R : Float64
    G : Float64
    B : Float64
    A : Float64
  end
  fun drawing_color_alpha_from_int = granite_drawing_color_alpha_from_int(color : Int32) : UInt8
  fun drawing_color_red_from_int = granite_drawing_color_red_from_int(color : Int32) : UInt8
  fun drawing_color_green_from_int = granite_drawing_color_green_from_int(color : Int32) : UInt8
  fun drawing_color_blue_from_int = granite_drawing_color_blue_from_int(color : Int32) : UInt8
  fun drawing_color_new = granite_drawing_color_new(R : Float64, G : Float64, B : Float64, A : Float64) : LibGranite::DrawingColor*
  fun drawing_color_from_gdk = granite_drawing_color_new_from_gdk(color : LibGdk::Color) : LibGranite::DrawingColor*
  fun drawing_color_from_rgba = granite_drawing_color_new_from_rgba(color : LibGdk::RGBA) : LibGranite::DrawingColor*
  fun drawing_color_from_string = granite_drawing_color_new_from_string(color : UInt8*) : LibGranite::DrawingColor*
  fun drawing_color_from_int = granite_drawing_color_new_from_int(color : Int32) : LibGranite::DrawingColor*
  fun drawing_color_set_hue = granite_drawing_color_set_hue(this : DrawingColor*, hue : Float64) : LibGranite::DrawingColor*
...
```

Crystal does not like that:

```
In granitetest.cr:82:5

 82 | R : Float64
      ^
Error: expecting identifier 'end', not 'R'
```

So this PR fixes that by prepending `_`s to them:
```crystal
struct DrawingColor # object
    parent_instance : LibGObject::Object*
    priv : LibGranite::DrawingColorPrivate*
    _R : Float64
    _G : Float64
    _B : Float64
    _A : Float64
  end
  fun drawing_color_alpha_from_int = granite_drawing_color_alpha_from_int(color : Int32) : UInt8
  fun drawing_color_red_from_int = granite_drawing_color_red_from_int(color : Int32) : UInt8
  fun drawing_color_green_from_int = granite_drawing_color_green_from_int(color : Int32) : UInt8
  fun drawing_color_blue_from_int = granite_drawing_color_blue_from_int(color : Int32) : UInt8
  fun drawing_color_new = granite_drawing_color_new(_R : Float64, _G : Float64, _B : Float64, _A : Float64) : LibGranite::DrawingColor*
  fun drawing_color_from_gdk = granite_drawing_color_new_from_gdk(color : LibGdk::Color) : LibGranite::DrawingColor*
  fun drawing_color_from_rgba = granite_drawing_color_new_from_rgba(color : LibGdk::RGBA) : LibGranite::DrawingColor*
  fun drawing_color_from_string = granite_drawing_color_new_from_string(color : UInt8*) : LibGranite::DrawingColor*
  fun drawing_color_from_int = granite_drawing_color_new_from_int(color : Int32) : LibGranite::DrawingColor*
  fun drawing_color_set_hue = granite_drawing_color_set_hue(this : DrawingColor*, hue : Float64) : LibGranite::DrawingColor*

```