### PR TITLE
`branch: 0.3.0` gives error

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Include in your shard.yml:
 dependencies:
   gobject:
     github: jhass/crystal-gobject
-    branch: 0.3.0
+    branch: master
 ```
 
 For libraries that have convenience wrappers you just require them under the `goject`


### PR DESCRIPTION
using `branch: 0.3.0` instead of `branch: master` gives this error:
`Failed git ls-tree -r --full-tree --name-only v0.3.0 -- shard.yml (). Maybe a commit, branch or file doesn't exist?`