### PR TITLE
Fix usage instructions on README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Include in your shard.yml:
 dependencies:
   gobject:
     github: jhass/crystal-gobject
-    branch: 0.3.1
+    version: ~> 0.3.1
 ```
 
 For libraries that have convenience wrappers you just require them under the `goject`


### PR DESCRIPTION
If you use the current instructions on shard.yml you get an error:
```
$ shards build
Resolving dependencies
Fetching https://github.com/jhass/crystal-gobject.git
Failed git log -n 1 --pretty=%H 0.3.1 (). Maybe a commit, branch or file doesn't exist?
```
This problem happen because branch 0.3.1 doesn't exist anymore. Anyway it's good to lock used libraries at a specific version or commit, so any build errors can be easily reproduceable.