### PR TITLE
Accept String besides Bytes when the parameter is an array of guint8.

### DIFF
--- a/samples/gtk_css_styling/css_window.cr
+++ b/samples/gtk_css_styling/css_window.cr
@@ -29,8 +29,7 @@ class CSSApp
   end
 
   def change_background(color)
-    # Workaround https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/1939 by calling to_slice
-    @css_provider.load_from_data "#css_window { background-color: #{color}; }".to_slice
+    @css_provider.load_from_data("#css_window { background-color: #{color}; }")
   end
 end
 

--- a/src/gtk/gtk.cr
+++ b/src/gtk/gtk.cr
@@ -29,7 +29,7 @@ module Gtk
 
   class CssProvider
     def load_from_data(string : String)
-      load_from_data(string, string.bytesize)
+      load_from_data(string.to_slice)
     end
   end
 


### PR DESCRIPTION
No idea why GTK annotate the data parameter of `gtk_css_provider_load_from_data` as `element-type guint8` but the C type is in fact `gchar*`, my guess if that bindings may assume that gchar is always a UTF8 string and the XML can be encoded in any other encoding.

Anyway... pass a string here is much more friendly.... and I think this shouldn't break other things.