### PR TITLE
map GLib.timeout -> g_timeout_add and GLib.timeout_seconds -> g_timeout_add_seconds

### DIFF
--- a/src/g_lib/g_lib.cr
+++ b/src/g_lib/g_lib.cr
@@ -1,3 +1,5 @@
+require "time"
+
 require "../gobject"
 require_gobject "GLib"
 
@@ -5,24 +7,63 @@ require "./*"
 require "../closure_data_manager"
 
 module GLib
-  def self.idle_add(&block : -> Bool)
+  enum Priority
+    Default      = LibGLib::PRIORITY_DEFAULT
+    Default_Idle = LibGLib::PRIORITY_DEFAULT_IDLE
+    High         = LibGLib::PRIORITY_HIGH
+    High_Idle    = LibGLib::PRIORITY_HIGH_IDLE
+    Low          = LibGLib::PRIORITY_LOW
+  end
+
+  def self.idle_add(priority : Priority = Priority::Default, &block : -> Bool)
     trampoline = LibGLib::SourceFunc.new { block.call ? 1 : 0 }
     LibGLib.idle_add(
-      LibGLib::PRIORITY_DEFAULT_IDLE,
+      priority,
       LibGLib::SourceFunc.new(trampoline.pointer, Pointer(Void).null),
       GObject::ClosureDataManager.register(trampoline.closure_data),
       ->GObject::ClosureDataManager.deregister
     )
   end
 
-  def self.timeout(seconds, &block : -> Bool)
+  # Calls *&block* every *interval* seconds until *&block* returns false.
+  # Can also be called implicitly with `#timeout`.
+  def self.timeout_seconds(interval : UInt32, priority : Priority = Priority::Default, &block : -> Bool)
+    raise ArgumentError.new("Timeout must be at least 1 second") unless interval > 0
     trampoline = LibGLib::SourceFunc.new { block.call ? 1 : 0 }
+    sourcefunc = LibGLib::SourceFunc.new(trampoline.pointer, Pointer(Void).null)
+    closure = GObject::ClosureDataManager.register(trampoline.closure_data)
     LibGLib.timeout_add_seconds(
-      LibGLib::PRIORITY_DEFAULT_IDLE,
-      UInt32.new(seconds),
-      LibGLib::SourceFunc.new(trampoline.pointer, Pointer(Void).null),
-      GObject::ClosureDataManager.register(trampoline.closure_data),
+      priority,
+      interval,
+      sourcefunc,
+      closure,
       ->GObject::ClosureDataManager.deregister
     )
+  end
+
+  # Calls *&block* every *interval* milliseconds until *&block* returns false.
+  # Can also be called implicitly with `#timeout`.
+  def self.timeout_milliseconds(interval : UInt32, priority : Priority = Priority::Default, &block : -> Bool)
+    raise ArgumentError.new("Timeout must be at least 1 millisecond") unless interval > 0
+    trampoline = LibGLib::SourceFunc.new { block.call ? 1 : 0 }
+    sourcefunc = LibGLib::SourceFunc.new(trampoline.pointer, Pointer(Void).null)
+    closure = GObject::ClosureDataManager.register(trampoline.closure_data)
+    LibGLib.timeout_add(
+      priority,
+      interval,
+      sourcefunc,
+      closure,
+      ->GObject::ClosureDataManager.deregister
+    )
+  end
+
+  # Calls *&block* every *interval* until *&block* returns false.
+  # If milliseconds are not specified or the interval is bigger than `UInt32::Max` milliseconds, `#timeout_seconds` is called, else `#timeout_milliseconds` is called.
+  def self.timeout(interval : Time::Span, priority : Priority = Priority::Default, &block : -> Bool)
+    if interval.to_i == interval.total_seconds || interval.total_milliseconds > UInt32::MAX
+      self.timeout_seconds(interval.total_seconds.to_u32, priority, &block)
+    else
+      self.timeout_milliseconds(interval.total_milliseconds.to_u32, priority, &block)
+    end
   end
 end


### PR DESCRIPTION
breaking changes wrt the side effects of GLib.timeout now using milliseconds instead of seconds
GLib.timeout has been renamed to Glib.timeout_seconds
GLib::Priority has been added to map LibGLib::PRIORITY_* constants
GLib.timeout and GLib.timeout_seconds now take a priority argument that defaults to GLib::Priority::Default

i think that the most intuitive thing for GLib.timeout to call is g_timeout_add, with a new GLib.timeout_seconds calling g_timeout_add_seconds. the timeout, timeout_seconds, and idle_add methods have also been changed to take an optional priority argument that defaults to LibGLib::PRIORITY_DEFAULT, which is what [g_timeout_add uses](https://developer.gnome.org/glib/stable/glib-The-Main-Event-Loop.html#g-timeout-add)