### PR TITLE
Some steps towards Crystal 0.36 support.

### DIFF
--- a/spec/basic_spec.cr
+++ b/spec/basic_spec.cr
@@ -19,4 +19,28 @@ describe "GObject Binding" do
       subject.receive_optional_array_and_len(buf).should eq 2
     end
   end
+
+  describe "nullable parameters" do
+    it "can receive nil" do
+      subject = Test::Subject.new
+      subject.receive_nullable_object(nil).should eq(1)
+    end
+
+    it "can receive nil" do
+      subject = Test::Subject.new
+      subject.receive_nullable_object(subject).should eq(0)
+    end
+  end
+
+  describe "parameters named using Crystal keywords" do
+    it "works on gobject parameters" do
+      subject = Test::Subject.new
+      subject.receive_arguments_named_as_crystal_keywords(1, 2, 3, 4, 5, 6, 7, 8, 9).should eq(45)
+    end
+
+    it "works on plain structs" do
+      subject = Test::Struct.new(in: 42)
+      subject.in.should eq(42)
+    end
+  end
 end

--- a/spec/libsample/test-subject.c
+++ b/spec/libsample/test-subject.c
@@ -98,3 +98,10 @@ int test_subject_receive_optional_array_and_len(TestSubject *self, const char* b
   return len;
 }
 
+int test_subject_receive_nullable_object(TestSubject *self, TestSubject* nullable) {
+  return nullable == NULL;
+}
+
+int test_subject_receive_arguments_named_as_crystal_keywords(TestSubject *self_, int def, int alias, int module, int out, int begin, int self, int end, int abstract, int in) {
+  return def + alias + module + out + begin + self + end + abstract + in;
+}

--- a/spec/libsample/test-subject.h
+++ b/spec/libsample/test-subject.h
@@ -5,6 +5,19 @@
 
 G_BEGIN_DECLS
 
+
+/**
+ * TestStruct:
+ * @in: A attribute using a invalid Crystal keyword.
+ * @begin: Another attribute using a invalid Crystal keyword.
+ *
+ * A plain struct to test stuff
+ */
+struct TestStruct {
+  gint16 in;
+  gint16 begin;
+};
+
 #define TEST_TYPE_SUBJECT test_subject_get_type()
 G_DECLARE_DERIVABLE_TYPE(TestSubject, test_subject, TEST, SUBJECT, GObject)
 
@@ -35,5 +48,18 @@ gchar *test_subject_receive_string_and_len(TestSubject *self, gchar* str, int le
  * Returns: "buffer length"
  */
 int test_subject_receive_optional_array_and_len(TestSubject *self, const char* buf, int length);
+
+/**
+ * test_subject_receive_nullable_object
+ * @nullable: (allow-none): A nullable object
+ * Returns: 1 if nullable is null, 0 otherwise
+ */
+int test_subject_receive_nullable_object(TestSubject *self, TestSubject* nullable);
+
+/**
+ * test_subject_receive_arguments_named_as_crystal_keywords
+ * Returns: Sum of all parameters
+ */
+int test_subject_receive_arguments_named_as_crystal_keywords(TestSubject *self_, int def, int alias, int module, int out, int begin, int self, int end, int abstract, int in);
 
 G_END_DECLS

--- a/src/g_i_repository/info/arg_info.cr
+++ b/src/g_i_repository/info/arg_info.cr
@@ -2,7 +2,7 @@ require "./base_info"
 
 module GIRepository
   class ArgInfo < BaseInfo
-    KEYWORDS = {"def", "alias", "module", "out", "begin", "self", "end", "abstract"}
+    KEYWORDS = {"def", "alias", "module", "out", "begin", "self", "end", "abstract", "in", "end", "next"}
 
     def name
       name = super
@@ -106,7 +106,7 @@ module GIRepository
       else
         # TODO: workaround https://github.com/crystal-lang/crystal/issues/4209
         if nullable?
-          "#{name} ? #{type.convert_from_crystal(name)} : nil"
+          "#{name} ? #{type.convert_from_crystal(name)} : #{type.convert_to_null}"
         else
           type.convert_from_crystal(name)
         end

--- a/src/g_i_repository/info/field_info.cr
+++ b/src/g_i_repository/info/field_info.cr
@@ -2,7 +2,7 @@ require "./base_info"
 
 module GIRepository
   class FieldInfo < BaseInfo
-    KEYWORDS = {"end", "next"}
+    KEYWORDS = ArgInfo::KEYWORDS
 
     def type
       BaseInfo.wrap(GIRepository.field_info_get_type(self)).as(TypeInfo)

--- a/src/g_i_repository/info/type_info.cr
+++ b/src/g_i_repository/info/type_info.cr
@@ -245,6 +245,20 @@ module GIRepository
       end
     end
 
+    def convert_to_null : String
+      case tag
+      when .utf8?, .filename?, .uint8?
+        return "Pointer(UInt8).null"
+      when .array?
+        return "Pointer(UInt8).null" if param_type.tag.uint8?
+      when .interface?
+        return "Pointer(Lib#{interface.full_constant}).null"
+      when .void?
+        return "Pointer(Void).null"
+      end
+      "nil" # this will probably get a compiler error.
+    end
+
     def unwrap_gvalue(variable)
       case tag
       when .interface?

--- a/src/generated/g_i_repository/module_functions.cr
+++ b/src/generated/g_i_repository/module_functions.cr
@@ -365,32 +365,32 @@ module GIRepository
 
   def self.object_info_find_method(info : GIRepository::BaseInfo, name : ::String)
     __var0 = LibGIRepository.object_info_find_method(info.to_unsafe.as(LibGIRepository::BaseInfo*), name.to_unsafe)
-    GObject.raise_unexpected_null("g_object_info_find_method") if __var0.null?
-    GIRepository::BaseInfo.new(__var0)
+    __var1 = GIRepository::BaseInfo.new(__var0) if __var0
+    __var1
   end
 
   def self.object_info_find_method_using_interfaces(info : GIRepository::BaseInfo, name : ::String, implementor : GIRepository::BaseInfo)
     __var0 = LibGIRepository.object_info_find_method_using_interfaces(info.to_unsafe.as(LibGIRepository::BaseInfo*), name.to_unsafe, implementor)
-    GObject.raise_unexpected_null("g_object_info_find_method_using_interfaces") if __var0.null?
-    GIRepository::BaseInfo.new(__var0)
+    __var1 = GIRepository::BaseInfo.new(__var0) if __var0
+    __var1
   end
 
   def self.object_info_find_signal(info : GIRepository::BaseInfo, name : ::String)
     __var0 = LibGIRepository.object_info_find_signal(info.to_unsafe.as(LibGIRepository::BaseInfo*), name.to_unsafe)
-    GObject.raise_unexpected_null("g_object_info_find_signal") if __var0.null?
-    GIRepository::BaseInfo.new(__var0)
+    __var1 = GIRepository::BaseInfo.new(__var0) if __var0
+    __var1
   end
 
   def self.object_info_find_vfunc(info : GIRepository::BaseInfo, name : ::String)
     __var0 = LibGIRepository.object_info_find_vfunc(info.to_unsafe.as(LibGIRepository::BaseInfo*), name.to_unsafe)
-    GObject.raise_unexpected_null("g_object_info_find_vfunc") if __var0.null?
-    GIRepository::BaseInfo.new(__var0)
+    __var1 = GIRepository::BaseInfo.new(__var0) if __var0
+    __var1
   end
 
   def self.object_info_find_vfunc_using_interfaces(info : GIRepository::BaseInfo, name : ::String, implementor : GIRepository::BaseInfo)
     __var0 = LibGIRepository.object_info_find_vfunc_using_interfaces(info.to_unsafe.as(LibGIRepository::BaseInfo*), name.to_unsafe, implementor)
-    GObject.raise_unexpected_null("g_object_info_find_vfunc_using_interfaces") if __var0.null?
-    GIRepository::BaseInfo.new(__var0)
+    __var1 = GIRepository::BaseInfo.new(__var0) if __var0
+    __var1
   end
 
   def self.object_info_get_abstract(info : GIRepository::BaseInfo)
@@ -400,8 +400,8 @@ module GIRepository
 
   def self.object_info_get_class_struct(info : GIRepository::BaseInfo)
     __var0 = LibGIRepository.object_info_get_class_struct(info.to_unsafe.as(LibGIRepository::BaseInfo*))
-    GObject.raise_unexpected_null("g_object_info_get_class_struct") if __var0.null?
-    GIRepository::BaseInfo.new(__var0)
+    __var1 = GIRepository::BaseInfo.new(__var0) if __var0
+    __var1
   end
 
   def self.object_info_get_constant(info : GIRepository::BaseInfo, n : ::Int)
@@ -423,8 +423,8 @@ module GIRepository
 
   def self.object_info_get_get_value_function(info : GIRepository::BaseInfo)
     __var0 = LibGIRepository.object_info_get_get_value_function(info.to_unsafe.as(LibGIRepository::BaseInfo*))
-    GObject.raise_unexpected_null("g_object_info_get_get_value_function") if __var0.null?
-    ::String.new(__var0)
+    __var1 = ::String.new(__var0) if __var0
+    __var1
   end
 
   def self.object_info_get_interface(info : GIRepository::BaseInfo, n : ::Int)
@@ -476,8 +476,8 @@ module GIRepository
 
   def self.object_info_get_parent(info : GIRepository::BaseInfo)
     __var0 = LibGIRepository.object_info_get_parent(info.to_unsafe.as(LibGIRepository::BaseInfo*))
-    GObject.raise_unexpected_null("g_object_info_get_parent") if __var0.null?
-    GIRepository::BaseInfo.new(__var0)
+    __var1 = GIRepository::BaseInfo.new(__var0) if __var0
+    __var1
   end
 
   def self.object_info_get_property(info : GIRepository::BaseInfo, n : ::Int)
@@ -488,14 +488,14 @@ module GIRepository
 
   def self.object_info_get_ref_function(info : GIRepository::BaseInfo)
     __var0 = LibGIRepository.object_info_get_ref_function(info.to_unsafe.as(LibGIRepository::BaseInfo*))
-    GObject.raise_unexpected_null("g_object_info_get_ref_function") if __var0.null?
-    ::String.new(__var0)
+    __var1 = ::String.new(__var0) if __var0
+    __var1
   end
 
   def self.object_info_get_set_value_function(info : GIRepository::BaseInfo)
     __var0 = LibGIRepository.object_info_get_set_value_function(info.to_unsafe.as(LibGIRepository::BaseInfo*))
-    GObject.raise_unexpected_null("g_object_info_get_set_value_function") if __var0.null?
-    ::String.new(__var0)
+    __var1 = ::String.new(__var0) if __var0
+    __var1
   end
 
   def self.object_info_get_signal(info : GIRepository::BaseInfo, n : ::Int)
@@ -518,8 +518,8 @@ module GIRepository
 
   def self.object_info_get_unref_function(info : GIRepository::BaseInfo)
     __var0 = LibGIRepository.object_info_get_unref_function(info.to_unsafe.as(LibGIRepository::BaseInfo*))
-    GObject.raise_unexpected_null("g_object_info_get_unref_function") if __var0.null?
-    ::String.new(__var0)
+    __var1 = ::String.new(__var0) if __var0
+    __var1
   end
 
   def self.object_info_get_vfunc(info : GIRepository::BaseInfo, n : ::Int)
@@ -631,6 +631,11 @@ module GIRepository
     (__var0 == 1)
   end
 
+  def self.type_info_argument_from_hash_pointer(info : GIRepository::BaseInfo, hash_pointer : Void*?, arg : GIRepository::Argument::Union)
+    LibGIRepository.type_info_argument_from_hash_pointer(info.to_unsafe.as(LibGIRepository::BaseInfo*), hash_pointer ? hash_pointer : nil, arg.to_unsafe.as(LibGIRepository::Argument*))
+    nil
+  end
+
   def self.type_info_get_array_fixed_size(info : GIRepository::BaseInfo)
     __var0 = LibGIRepository.type_info_get_array_fixed_size(info.to_unsafe.as(LibGIRepository::BaseInfo*))
     __var0
@@ -658,9 +663,19 @@ module GIRepository
     GIRepository::BaseInfo.new(__var0)
   end
 
+  def self.type_info_get_storage_type(info : GIRepository::BaseInfo)
+    __var0 = LibGIRepository.type_info_get_storage_type(info.to_unsafe.as(LibGIRepository::BaseInfo*))
+    GIRepository::TypeTag.new(__var0)
+  end
+
   def self.type_info_get_tag(info : GIRepository::BaseInfo)
     __var0 = LibGIRepository.type_info_get_tag(info.to_unsafe.as(LibGIRepository::BaseInfo*))
     GIRepository::TypeTag.new(__var0)
+  end
+
+  def self.type_info_hash_pointer_from_argument(info : GIRepository::BaseInfo, arg : GIRepository::Argument::Union)
+    LibGIRepository.type_info_hash_pointer_from_argument(info.to_unsafe.as(LibGIRepository::BaseInfo*), arg.to_unsafe.as(LibGIRepository::Argument*))
+    nil
   end
 
   def self.type_info_is_pointer(info : GIRepository::BaseInfo)

--- a/src/generated/g_i_repository/repository.cr
+++ b/src/generated/g_i_repository/repository.cr
@@ -137,8 +137,8 @@ module GIRepository
 
     def shared_library(namespace_ : ::String)
       __var0 = LibGIRepository.repository_get_shared_library(@pointer.as(LibGIRepository::Repository*), namespace_.to_unsafe)
-      GObject.raise_unexpected_null("g_irepository_get_shared_library") if __var0.null?
-      ::String.new(__var0)
+      __var1 = ::String.new(__var0) if __var0
+      __var1
     end
 
     def typelib_path(namespace_ : ::String)

--- a/src/generated/g_i_repository/repository.cr
+++ b/src/generated/g_i_repository/repository.cr
@@ -154,7 +154,7 @@ module GIRepository
     end
 
     def registered?(namespace_ : ::String, version : ::String?)
-      __var0 = LibGIRepository.repository_is_registered(@pointer.as(LibGIRepository::Repository*), namespace_.to_unsafe, version ? version.to_unsafe : nil)
+      __var0 = LibGIRepository.repository_is_registered(@pointer.as(LibGIRepository::Repository*), namespace_.to_unsafe, version ? version.to_unsafe : Pointer(UInt8).null)
       (__var0 == 1)
     end
 
@@ -168,7 +168,7 @@ module GIRepository
 
     def require(namespace_ : ::String, version : ::String?, flags : GIRepository::RepositoryLoadFlags)
       __var0 = Pointer(LibGLib::Error).null
-      __var1 = LibGIRepository.repository_require(@pointer.as(LibGIRepository::Repository*), namespace_.to_unsafe, version ? version.to_unsafe : nil, flags, pointerof(__var0))
+      __var1 = LibGIRepository.repository_require(@pointer.as(LibGIRepository::Repository*), namespace_.to_unsafe, version ? version.to_unsafe : Pointer(UInt8).null, flags, pointerof(__var0))
       GLib::Error.assert(__var0)
       GObject.raise_unexpected_null("g_irepository_require") if __var1.null?
       GIRepository::Typelib.new(__var1)
@@ -176,7 +176,7 @@ module GIRepository
 
     def require_private(typelib_dir : ::String, namespace_ : ::String, version : ::String?, flags : GIRepository::RepositoryLoadFlags)
       __var0 = Pointer(LibGLib::Error).null
-      __var1 = LibGIRepository.repository_require_private(@pointer.as(LibGIRepository::Repository*), typelib_dir.to_unsafe, namespace_.to_unsafe, version ? version.to_unsafe : nil, flags, pointerof(__var0))
+      __var1 = LibGIRepository.repository_require_private(@pointer.as(LibGIRepository::Repository*), typelib_dir.to_unsafe, namespace_.to_unsafe, version ? version.to_unsafe : Pointer(UInt8).null, flags, pointerof(__var0))
       GLib::Error.assert(__var0)
       GObject.raise_unexpected_null("g_irepository_require_private") if __var1.null?
       GIRepository::Typelib.new(__var1)

--- a/src/generated/lib_g_i_repository.cr
+++ b/src/generated/lib_g_i_repository.cr
@@ -117,7 +117,7 @@ lib LibGIRepository
   ###########################################
   MAJOR_VERSION = 1 # : Int32
   MICRO_VERSION = 1 # : Int32
-  MINOR_VERSION = 64 # : Int32
+  MINOR_VERSION = 66 # : Int32
   TYPE_TAG_N_TYPES = 22 # : Int32
 
   ###########################################
@@ -270,12 +270,15 @@ lib LibGIRepository
   fun struct_info_get_size = g_struct_info_get_size(info : LibGIRepository::BaseInfo*) : UInt64
   fun struct_info_is_foreign = g_struct_info_is_foreign(info : LibGIRepository::BaseInfo*) : LibC::Int
   fun struct_info_is_gtype_struct = g_struct_info_is_gtype_struct(info : LibGIRepository::BaseInfo*) : LibC::Int
+  fun type_info_argument_from_hash_pointer = g_type_info_argument_from_hash_pointer(info : LibGIRepository::BaseInfo*, hash_pointer : Void*, arg : LibGIRepository::Argument*) : Void
   fun type_info_get_array_fixed_size = g_type_info_get_array_fixed_size(info : LibGIRepository::BaseInfo*) : Int32
   fun type_info_get_array_length = g_type_info_get_array_length(info : LibGIRepository::BaseInfo*) : Int32
   fun type_info_get_array_type = g_type_info_get_array_type(info : LibGIRepository::BaseInfo*) : LibGIRepository::ArrayType
   fun type_info_get_interface = g_type_info_get_interface(info : LibGIRepository::BaseInfo*) : LibGIRepository::BaseInfo*
   fun type_info_get_param_type = g_type_info_get_param_type(info : LibGIRepository::BaseInfo*, n : Int32) : LibGIRepository::BaseInfo*
+  fun type_info_get_storage_type = g_type_info_get_storage_type(info : LibGIRepository::BaseInfo*) : LibGIRepository::TypeTag
   fun type_info_get_tag = g_type_info_get_tag(info : LibGIRepository::BaseInfo*) : LibGIRepository::TypeTag
+  fun type_info_hash_pointer_from_argument = g_type_info_hash_pointer_from_argument(info : LibGIRepository::BaseInfo*, arg : LibGIRepository::Argument*) : Void*
   fun type_info_is_pointer = g_type_info_is_pointer(info : LibGIRepository::BaseInfo*) : LibC::Int
   fun type_info_is_zero_terminated = g_type_info_is_zero_terminated(info : LibGIRepository::BaseInfo*) : LibC::Int
   fun type_tag_to_string = g_type_tag_to_string(type : LibGIRepository::TypeTag) : UInt8*

--- a/src/generated/lib_g_lib.cr
+++ b/src/generated/lib_g_lib.cr
@@ -1678,7 +1678,7 @@ lib LibGLib
   fun base64_decode_inplace = g_base64_decode_inplace(text : UInt8**, out_len : UInt64*) : UInt8*
   fun base64_encode = g_base64_encode(data : UInt8*, len : UInt64) : UInt8*
   fun base64_encode_close = g_base64_encode_close(break_lines : LibC::Int, _out : UInt8**, state : Int32*, save : Int32*) : UInt64
-  fun base64_encode_step = g_base64_encode_step(in : UInt8*, len : UInt64, break_lines : LibC::Int, _out : UInt8**, state : Int32*, save : Int32*) : UInt64
+  fun base64_encode_step = g_base64_encode_step(_in : UInt8*, len : UInt64, break_lines : LibC::Int, _out : UInt8**, state : Int32*, save : Int32*) : UInt64
   fun basename = g_basename(file_name : UInt8*) : UInt8*
   fun bit_lock = g_bit_lock(address : Int32*, lock_bit : Int32) : Void
   fun bit_nth_lsf = g_bit_nth_lsf(mask : UInt64, nth_bit : Int32) : Int32

--- a/src/generated/lib_g_lib.cr
+++ b/src/generated/lib_g_lib.cr
@@ -22,8 +22,8 @@ lib LibGLib
   GINT16_MODIFIER = "h" # : UInt8*
   GINT32_FORMAT = "i" # : UInt8*
   GINT32_MODIFIER = "" # : UInt8*
-  GINT64_FORMAT = "lli" # : UInt8*
-  GINT64_MODIFIER = "ll" # : UInt8*
+  GINT64_FORMAT = "li" # : UInt8*
+  GINT64_MODIFIER = "l" # : UInt8*
   GINTPTR_FORMAT = "li" # : UInt8*
   GINTPTR_MODIFIER = "l" # : UInt8*
   GNUC_FUNCTION = "" # : UInt8*
@@ -34,7 +34,7 @@ lib LibGLib
   GSSIZE_MODIFIER = "l" # : UInt8*
   GUINT16_FORMAT = "hu" # : UInt8*
   GUINT32_FORMAT = "u" # : UInt8*
-  GUINT64_FORMAT = "llu" # : UInt8*
+  GUINT64_FORMAT = "lu" # : UInt8*
   GUINTPTR_FORMAT = "lu" # : UInt8*
   HAVE_GINT64 = 1 # : Int32
   HAVE_GNUC_VARARGS = 1 # : Int32
@@ -85,12 +85,12 @@ lib LibGLib
   MAXUINT32 = 4294967295 # : UInt32
   MAXUINT64 = 18446744073709551615u64 # : UInt64
   MAXUINT8 = 255u8 # : UInt8
-  MICRO_VERSION = 3 # : Int32
+  MICRO_VERSION = 2 # : Int32
   MININT16 = -32768i16 # : Int16
   MININT32 = -2147483648 # : Int32
   MININT64 = -9223372036854775808i64 # : Int64
   MININT8 = -128i8 # : Int8
-  MINOR_VERSION = 64 # : Int32
+  MINOR_VERSION = 66 # : Int32
   MODULE_SUFFIX = "so" # : UInt8*
   OPTION_REMAINING = "" # : UInt8*
   PDP_ENDIAN = 3412 # : Int32
@@ -115,7 +115,7 @@ lib LibGLib
   SQRT2 = 1.414214 # : Float64
   STR_DELIMITERS = "_-|> <." # : UInt8*
   SYSDEF_AF_INET = 2 # : Int32
-  SYSDEF_AF_INET6 = 30 # : Int32
+  SYSDEF_AF_INET6 = 10 # : Int32
   SYSDEF_AF_UNIX = 1 # : Int32
   SYSDEF_MSG_DONTROUTE = 4 # : Int32
   SYSDEF_MSG_OOB = 1 # : Int32
@@ -176,7 +176,9 @@ lib LibGLib
   fun bookmark_file_add_group = g_bookmark_file_add_group(this : BookmarkFile*, uri : UInt8*, group : UInt8*) : Void
   fun bookmark_file_free = g_bookmark_file_free(this : BookmarkFile*) : Void
   fun bookmark_file_get_added = g_bookmark_file_get_added(this : BookmarkFile*, uri : UInt8*, error : LibGLib::Error**) : Int64
+  fun bookmark_file_get_added_date_time = g_bookmark_file_get_added_date_time(this : BookmarkFile*, uri : UInt8*, error : LibGLib::Error**) : LibGLib::DateTime*
   fun bookmark_file_get_app_info = g_bookmark_file_get_app_info(this : BookmarkFile*, uri : UInt8*, name : UInt8*, exec : UInt8**, count : UInt32*, stamp : Int64*, error : LibGLib::Error**) : LibC::Int
+  fun bookmark_file_get_application_info = g_bookmark_file_get_application_info(this : BookmarkFile*, uri : UInt8*, name : UInt8*, exec : UInt8**, count : UInt32*, stamp : LibGLib::DateTime**, error : LibGLib::Error**) : LibC::Int
   fun bookmark_file_get_applications = g_bookmark_file_get_applications(this : BookmarkFile*, uri : UInt8*, length : UInt64*, error : LibGLib::Error**) : UInt8**
   fun bookmark_file_get_description = g_bookmark_file_get_description(this : BookmarkFile*, uri : UInt8*, error : LibGLib::Error**) : UInt8*
   fun bookmark_file_get_groups = g_bookmark_file_get_groups(this : BookmarkFile*, uri : UInt8*, length : UInt64*, error : LibGLib::Error**) : UInt8**
@@ -184,10 +186,12 @@ lib LibGLib
   fun bookmark_file_get_is_private = g_bookmark_file_get_is_private(this : BookmarkFile*, uri : UInt8*, error : LibGLib::Error**) : LibC::Int
   fun bookmark_file_get_mime_type = g_bookmark_file_get_mime_type(this : BookmarkFile*, uri : UInt8*, error : LibGLib::Error**) : UInt8*
   fun bookmark_file_get_modified = g_bookmark_file_get_modified(this : BookmarkFile*, uri : UInt8*, error : LibGLib::Error**) : Int64
+  fun bookmark_file_get_modified_date_time = g_bookmark_file_get_modified_date_time(this : BookmarkFile*, uri : UInt8*, error : LibGLib::Error**) : LibGLib::DateTime*
   fun bookmark_file_get_size = g_bookmark_file_get_size(this : BookmarkFile*) : Int32
   fun bookmark_file_get_title = g_bookmark_file_get_title(this : BookmarkFile*, uri : UInt8*, error : LibGLib::Error**) : UInt8*
   fun bookmark_file_get_uris = g_bookmark_file_get_uris(this : BookmarkFile*, length : UInt64*) : UInt8**
   fun bookmark_file_get_visited = g_bookmark_file_get_visited(this : BookmarkFile*, uri : UInt8*, error : LibGLib::Error**) : Int64
+  fun bookmark_file_get_visited_date_time = g_bookmark_file_get_visited_date_time(this : BookmarkFile*, uri : UInt8*, error : LibGLib::Error**) : LibGLib::DateTime*
   fun bookmark_file_has_application = g_bookmark_file_has_application(this : BookmarkFile*, uri : UInt8*, name : UInt8*, error : LibGLib::Error**) : LibC::Int
   fun bookmark_file_has_group = g_bookmark_file_has_group(this : BookmarkFile*, uri : UInt8*, group : UInt8*, error : LibGLib::Error**) : LibC::Int
   fun bookmark_file_has_item = g_bookmark_file_has_item(this : BookmarkFile*, uri : UInt8*) : LibC::Int
@@ -199,15 +203,19 @@ lib LibGLib
   fun bookmark_file_remove_group = g_bookmark_file_remove_group(this : BookmarkFile*, uri : UInt8*, group : UInt8*, error : LibGLib::Error**) : LibC::Int
   fun bookmark_file_remove_item = g_bookmark_file_remove_item(this : BookmarkFile*, uri : UInt8*, error : LibGLib::Error**) : LibC::Int
   fun bookmark_file_set_added = g_bookmark_file_set_added(this : BookmarkFile*, uri : UInt8*, added : Int64) : Void
+  fun bookmark_file_set_added_date_time = g_bookmark_file_set_added_date_time(this : BookmarkFile*, uri : UInt8*, added : LibGLib::DateTime*) : Void
   fun bookmark_file_set_app_info = g_bookmark_file_set_app_info(this : BookmarkFile*, uri : UInt8*, name : UInt8*, exec : UInt8*, count : Int32, stamp : Int64, error : LibGLib::Error**) : LibC::Int
+  fun bookmark_file_set_application_info = g_bookmark_file_set_application_info(this : BookmarkFile*, uri : UInt8*, name : UInt8*, exec : UInt8*, count : Int32, stamp : LibGLib::DateTime*, error : LibGLib::Error**) : LibC::Int
   fun bookmark_file_set_description = g_bookmark_file_set_description(this : BookmarkFile*, uri : UInt8*, description : UInt8*) : Void
   fun bookmark_file_set_groups = g_bookmark_file_set_groups(this : BookmarkFile*, uri : UInt8*, groups : UInt8**, length : UInt64) : Void
   fun bookmark_file_set_icon = g_bookmark_file_set_icon(this : BookmarkFile*, uri : UInt8*, href : UInt8*, mime_type : UInt8*) : Void
   fun bookmark_file_set_is_private = g_bookmark_file_set_is_private(this : BookmarkFile*, uri : UInt8*, is_private : LibC::Int) : Void
   fun bookmark_file_set_mime_type = g_bookmark_file_set_mime_type(this : BookmarkFile*, uri : UInt8*, mime_type : UInt8*) : Void
   fun bookmark_file_set_modified = g_bookmark_file_set_modified(this : BookmarkFile*, uri : UInt8*, modified : Int64) : Void
+  fun bookmark_file_set_modified_date_time = g_bookmark_file_set_modified_date_time(this : BookmarkFile*, uri : UInt8*, modified : LibGLib::DateTime*) : Void
   fun bookmark_file_set_title = g_bookmark_file_set_title(this : BookmarkFile*, uri : UInt8*, title : UInt8*) : Void
   fun bookmark_file_set_visited = g_bookmark_file_set_visited(this : BookmarkFile*, uri : UInt8*, visited : Int64) : Void
+  fun bookmark_file_set_visited_date_time = g_bookmark_file_set_visited_date_time(this : BookmarkFile*, uri : UInt8*, visited : LibGLib::DateTime*) : Void
   fun bookmark_file_to_data = g_bookmark_file_to_data(this : BookmarkFile*, length : UInt64*, error : LibGLib::Error**) : UInt8*
   fun bookmark_file_to_file = g_bookmark_file_to_file(this : BookmarkFile*, filename : UInt8*, error : LibGLib::Error**) : LibC::Int
   fun bookmark_file_error_quark = g_bookmark_file_error_quark : UInt32
@@ -1173,6 +1181,8 @@ lib LibGLib
     _data : UInt8[0]
   end
   fun _g_thread_get_type = g_thread_get_type : UInt64
+  fun thread_new = g_thread_new(name : UInt8*, func : LibGLib::ThreadFunc, data : Void*) : LibGLib::Thread*
+  fun thread_try_new = g_thread_try_new(name : UInt8*, func : LibGLib::ThreadFunc, data : Void*, error : LibGLib::Error**) : LibGLib::Thread*
   fun thread_join = g_thread_join(this : Thread*) : Void*
   fun thread_ref = g_thread_ref(this : Thread*) : LibGLib::Thread*
   fun thread_unref = g_thread_unref(this : Thread*) : Void
@@ -1257,6 +1267,54 @@ lib LibGLib
   fun tree_replace = g_tree_replace(this : Tree*, key : Void*, value : Void*) : Void
   fun tree_steal = g_tree_steal(this : Tree*, key : Void*) : LibC::Int
   fun tree_unref = g_tree_unref(this : Tree*) : Void
+
+  struct Uri # struct
+    _data : UInt8[0]
+  end
+  fun _g_uri_get_type = g_uri_get_type : UInt64
+  fun uri_get_auth_params = g_uri_get_auth_params(this : Uri*) : UInt8*
+  fun uri_get_flags = g_uri_get_flags(this : Uri*) : LibGLib::UriFlags
+  fun uri_get_fragment = g_uri_get_fragment(this : Uri*) : UInt8*
+  fun uri_get_host = g_uri_get_host(this : Uri*) : UInt8*
+  fun uri_get_password = g_uri_get_password(this : Uri*) : UInt8*
+  fun uri_get_path = g_uri_get_path(this : Uri*) : UInt8*
+  fun uri_get_port = g_uri_get_port(this : Uri*) : Int32
+  fun uri_get_query = g_uri_get_query(this : Uri*) : UInt8*
+  fun uri_get_scheme = g_uri_get_scheme(this : Uri*) : UInt8*
+  fun uri_get_user = g_uri_get_user(this : Uri*) : UInt8*
+  fun uri_get_userinfo = g_uri_get_userinfo(this : Uri*) : UInt8*
+  fun uri_parse_relative = g_uri_parse_relative(this : Uri*, uri_ref : UInt8*, flags : LibGLib::UriFlags, error : LibGLib::Error**) : LibGLib::Uri*
+  fun uri_to_string = g_uri_to_string(this : Uri*) : UInt8*
+  fun uri_to_string_partial = g_uri_to_string_partial(this : Uri*, flags : LibGLib::UriHideFlags) : UInt8*
+  fun uri_build = g_uri_build(flags : LibGLib::UriFlags, scheme : UInt8*, userinfo : UInt8*, host : UInt8*, port : Int32, path : UInt8*, query : UInt8*, fragment : UInt8*) : LibGLib::Uri*
+  fun uri_build_with_user = g_uri_build_with_user(flags : LibGLib::UriFlags, scheme : UInt8*, user : UInt8*, password : UInt8*, auth_params : UInt8*, host : UInt8*, port : Int32, path : UInt8*, query : UInt8*, fragment : UInt8*) : LibGLib::Uri*
+  fun uri_error_quark = g_uri_error_quark : UInt32
+  fun uri_escape_bytes = g_uri_escape_bytes(unescaped : UInt8*, length : UInt64, reserved_chars_allowed : UInt8*) : UInt8*
+  fun uri_escape_string = g_uri_escape_string(unescaped : UInt8*, reserved_chars_allowed : UInt8*, allow_utf8 : LibC::Int) : UInt8*
+  fun uri_is_valid = g_uri_is_valid(uri_string : UInt8*, flags : LibGLib::UriFlags, error : LibGLib::Error**) : LibC::Int
+  fun uri_join = g_uri_join(flags : LibGLib::UriFlags, scheme : UInt8*, userinfo : UInt8*, host : UInt8*, port : Int32, path : UInt8*, query : UInt8*, fragment : UInt8*) : UInt8*
+  fun uri_join_with_user = g_uri_join_with_user(flags : LibGLib::UriFlags, scheme : UInt8*, user : UInt8*, password : UInt8*, auth_params : UInt8*, host : UInt8*, port : Int32, path : UInt8*, query : UInt8*, fragment : UInt8*) : UInt8*
+  fun uri_list_extract_uris = g_uri_list_extract_uris(uri_list : UInt8*) : UInt8**
+  fun uri_parse = g_uri_parse(uri_string : UInt8*, flags : LibGLib::UriFlags, error : LibGLib::Error**) : LibGLib::Uri*
+  fun uri_parse_params = g_uri_parse_params(params : UInt8*, length : Int64, separators : UInt8*, flags : LibGLib::UriParamsFlags, error : LibGLib::Error**) : Void**
+  fun uri_parse_scheme = g_uri_parse_scheme(uri : UInt8*) : UInt8*
+  fun uri_peek_scheme = g_uri_peek_scheme(uri : UInt8*) : UInt8*
+  fun uri_resolve_relative = g_uri_resolve_relative(base_uri_string : UInt8*, uri_ref : UInt8*, flags : LibGLib::UriFlags, error : LibGLib::Error**) : UInt8*
+  fun uri_split = g_uri_split(uri_ref : UInt8*, flags : LibGLib::UriFlags, scheme : UInt8**, userinfo : UInt8**, host : UInt8**, port : Int32*, path : UInt8**, query : UInt8**, fragment : UInt8**, error : LibGLib::Error**) : LibC::Int
+  fun uri_split_network = g_uri_split_network(uri_string : UInt8*, flags : LibGLib::UriFlags, scheme : UInt8**, host : UInt8**, port : Int32*, error : LibGLib::Error**) : LibC::Int
+  fun uri_split_with_user = g_uri_split_with_user(uri_ref : UInt8*, flags : LibGLib::UriFlags, scheme : UInt8**, user : UInt8**, password : UInt8**, auth_params : UInt8**, host : UInt8**, port : Int32*, path : UInt8**, query : UInt8**, fragment : UInt8**, error : LibGLib::Error**) : LibC::Int
+  fun uri_unescape_bytes = g_uri_unescape_bytes(escaped_string : UInt8*, length : Int64, illegal_characters : UInt8*, error : LibGLib::Error**) : LibGLib::Bytes*
+  fun uri_unescape_segment = g_uri_unescape_segment(escaped_string : UInt8*, escaped_string_end : UInt8*, illegal_characters : UInt8*) : UInt8*
+  fun uri_unescape_string = g_uri_unescape_string(escaped_string : UInt8*, illegal_characters : UInt8*) : UInt8*
+
+  struct UriParamsIter # struct
+    dummy0 : Int32
+    dummy1 : Void*
+    dummy2 : Void*
+    dummy3 : UInt8[256]
+  end
+  fun uri_params_iter_init = g_uri_params_iter_init(this : UriParamsIter*, params : UInt8*, length : Int64, separators : UInt8*, flags : LibGLib::UriParamsFlags) : Void
+  fun uri_params_iter_next = g_uri_params_iter_next(this : UriParamsIter*, attribute : UInt8**, value : UInt8**, error : LibGLib::Error**) : LibC::Int
 
   struct Variant # struct
     _data : UInt8[0]
@@ -1407,6 +1465,8 @@ lib LibGLib
 
   alias AsciiType = UInt32
 
+  alias FileSetContentsFlags = UInt32
+
   alias FileTest = UInt32
 
   alias FormatSizeFlags = UInt32
@@ -1438,6 +1498,12 @@ lib LibGLib
   alias TestTrapFlags = UInt32
 
   alias TraverseFlags = UInt32
+
+  alias UriFlags = UInt32
+
+  alias UriHideFlags = UInt32
+
+  alias UriParamsFlags = UInt32
 
   ###########################################
   ##    Enums
@@ -1510,6 +1576,8 @@ lib LibGLib
   alias UnicodeScript = Int32
 
   alias UnicodeType = UInt32
+
+  alias UriError = UInt32
 
   alias UserDirectory = UInt32
 
@@ -1686,6 +1754,7 @@ lib LibGLib
   fun file_open_tmp = g_file_open_tmp(tmpl : UInt8*, name_used : UInt8**, error : LibGLib::Error**) : Int32
   fun file_read_link = g_file_read_link(filename : UInt8*, error : LibGLib::Error**) : UInt8*
   fun file_set_contents = g_file_set_contents(filename : UInt8*, contents : UInt8*, length : Int64, error : LibGLib::Error**) : LibC::Int
+  fun file_set_contents_full = g_file_set_contents_full(filename : UInt8*, contents : UInt8*, length : Int64, flags : LibGLib::FileSetContentsFlags, mode : Int32, error : LibGLib::Error**) : LibC::Int
   fun file_test = g_file_test(filename : UInt8*, test : LibGLib::FileTest) : LibC::Int
   fun filename_display_basename = g_filename_display_basename(filename : UInt8*) : UInt8*
   fun filename_display_name = g_filename_display_name(filename : UInt8*) : UInt8*
@@ -2042,9 +2111,24 @@ lib LibGLib
   fun unix_signal_source_new = g_unix_signal_source_new(signum : Int32) : LibGLib::Source*
   fun unlink = g_unlink(filename : UInt8*) : Int32
   fun unsetenv = g_unsetenv(variable : UInt8*) : Void
+  fun uri_build = g_uri_build(flags : LibGLib::UriFlags, scheme : UInt8*, userinfo : UInt8*, host : UInt8*, port : Int32, path : UInt8*, query : UInt8*, fragment : UInt8*) : LibGLib::Uri*
+  fun uri_build_with_user = g_uri_build_with_user(flags : LibGLib::UriFlags, scheme : UInt8*, user : UInt8*, password : UInt8*, auth_params : UInt8*, host : UInt8*, port : Int32, path : UInt8*, query : UInt8*, fragment : UInt8*) : LibGLib::Uri*
+  fun uri_error_quark = g_uri_error_quark : UInt32
+  fun uri_escape_bytes = g_uri_escape_bytes(unescaped : UInt8*, length : UInt64, reserved_chars_allowed : UInt8*) : UInt8*
   fun uri_escape_string = g_uri_escape_string(unescaped : UInt8*, reserved_chars_allowed : UInt8*, allow_utf8 : LibC::Int) : UInt8*
+  fun uri_is_valid = g_uri_is_valid(uri_string : UInt8*, flags : LibGLib::UriFlags, error : LibGLib::Error**) : LibC::Int
+  fun uri_join = g_uri_join(flags : LibGLib::UriFlags, scheme : UInt8*, userinfo : UInt8*, host : UInt8*, port : Int32, path : UInt8*, query : UInt8*, fragment : UInt8*) : UInt8*
+  fun uri_join_with_user = g_uri_join_with_user(flags : LibGLib::UriFlags, scheme : UInt8*, user : UInt8*, password : UInt8*, auth_params : UInt8*, host : UInt8*, port : Int32, path : UInt8*, query : UInt8*, fragment : UInt8*) : UInt8*
   fun uri_list_extract_uris = g_uri_list_extract_uris(uri_list : UInt8*) : UInt8**
+  fun uri_parse = g_uri_parse(uri_string : UInt8*, flags : LibGLib::UriFlags, error : LibGLib::Error**) : LibGLib::Uri*
+  fun uri_parse_params = g_uri_parse_params(params : UInt8*, length : Int64, separators : UInt8*, flags : LibGLib::UriParamsFlags, error : LibGLib::Error**) : Void**
   fun uri_parse_scheme = g_uri_parse_scheme(uri : UInt8*) : UInt8*
+  fun uri_peek_scheme = g_uri_peek_scheme(uri : UInt8*) : UInt8*
+  fun uri_resolve_relative = g_uri_resolve_relative(base_uri_string : UInt8*, uri_ref : UInt8*, flags : LibGLib::UriFlags, error : LibGLib::Error**) : UInt8*
+  fun uri_split = g_uri_split(uri_ref : UInt8*, flags : LibGLib::UriFlags, scheme : UInt8**, userinfo : UInt8**, host : UInt8**, port : Int32*, path : UInt8**, query : UInt8**, fragment : UInt8**, error : LibGLib::Error**) : LibC::Int
+  fun uri_split_network = g_uri_split_network(uri_string : UInt8*, flags : LibGLib::UriFlags, scheme : UInt8**, host : UInt8**, port : Int32*, error : LibGLib::Error**) : LibC::Int
+  fun uri_split_with_user = g_uri_split_with_user(uri_ref : UInt8*, flags : LibGLib::UriFlags, scheme : UInt8**, user : UInt8**, password : UInt8**, auth_params : UInt8**, host : UInt8**, port : Int32*, path : UInt8**, query : UInt8**, fragment : UInt8**, error : LibGLib::Error**) : LibC::Int
+  fun uri_unescape_bytes = g_uri_unescape_bytes(escaped_string : UInt8*, length : Int64, illegal_characters : UInt8*, error : LibGLib::Error**) : LibGLib::Bytes*
   fun uri_unescape_segment = g_uri_unescape_segment(escaped_string : UInt8*, escaped_string_end : UInt8*, illegal_characters : UInt8*) : UInt8*
   fun uri_unescape_string = g_uri_unescape_string(escaped_string : UInt8*, illegal_characters : UInt8*) : UInt8*
   fun usleep = g_usleep(microseconds : UInt64) : Void

--- a/src/generated/lib_g_object.cr
+++ b/src/generated/lib_g_object.cr
@@ -86,6 +86,7 @@ lib LibGObject
     # Virtual function value_validate
     # Virtual function values_cmp
   end
+  fun param_spec_is_valid_name = g_param_spec_is_valid_name(name : UInt8*) : LibC::Int
   fun param_spec_get_blurb = g_param_spec_get_blurb(this : ParamSpec*) : UInt8*
   fun param_spec_get_default_value = g_param_spec_get_default_value(this : ParamSpec*) : LibGObject::Value*
   fun param_spec_get_name = g_param_spec_get_name(this : ParamSpec*) : UInt8*
@@ -591,6 +592,7 @@ lib LibGObject
   fun value_set_instance = g_value_set_instance(this : Value*, instance : Void*) : Void
   fun value_set_int = g_value_set_int(this : Value*, v_int : Int32) : Void
   fun value_set_int64 = g_value_set_int64(this : Value*, v_int64 : Int64) : Void
+  fun value_set_interned_string = g_value_set_interned_string(this : Value*, v_string : UInt8*) : Void
   fun value_set_long = g_value_set_long(this : Value*, v_long : Int64) : Void
   fun value_set_object = g_value_set_object(this : Value*, v_object : LibGObject::Object*) : Void
   fun value_set_param = g_value_set_param(this : Value*, param : LibGObject::ParamSpec*) : Void
@@ -648,6 +650,7 @@ lib LibGObject
   TYPE_RESERVED_GLIB_FIRST = 22 # : Int32
   TYPE_RESERVED_GLIB_LAST = 31 # : Int32
   TYPE_RESERVED_USER_FIRST = 49 # : Int32
+  VALUE_INTERNED_STRING = 268435456 # : Int32
   VALUE_NOCOPY_CONTENTS = 134217728 # : Int32
 
   ###########################################
@@ -769,6 +772,7 @@ lib LibGObject
   fun signal_handlers_disconnect_matched = g_signal_handlers_disconnect_matched(instance : LibGObject::Object*, mask : LibGObject::SignalMatchType, signal_id : UInt32, detail : UInt32, closure : LibGObject::Closure*, func : Void*, data : Void*) : UInt32
   fun signal_handlers_unblock_matched = g_signal_handlers_unblock_matched(instance : LibGObject::Object*, mask : LibGObject::SignalMatchType, signal_id : UInt32, detail : UInt32, closure : LibGObject::Closure*, func : Void*, data : Void*) : UInt32
   fun signal_has_handler_pending = g_signal_has_handler_pending(instance : LibGObject::Object*, signal_id : UInt32, detail : UInt32, may_be_blocked : LibC::Int) : LibC::Int
+  fun signal_is_valid_name = g_signal_is_valid_name(name : UInt8*) : LibC::Int
   fun signal_list_ids = g_signal_list_ids(itype : UInt64, n_ids : UInt32*) : UInt32*
   fun signal_lookup = g_signal_lookup(name : UInt8*, itype : UInt64) : UInt32
   fun signal_name = g_signal_name(signal_id : UInt32) : UInt8*


### PR DESCRIPTION
I was trying to make the generator work with Crystal 0.36, I fixed some stuff (not sure if in the better/complete way) and added some tests, by what I remember there are basically two issues:

- `nil vs Pointer(T).null` when passing parameters to C functions.
- Attributes using keywords in C Structs and object methods.

The fix doesn't really fix all issues, since my app still failing to compile, mainly with `nil` vs `Pointer.null` issues (i.e. the few tests I wrote doesn't cover all basic use cases), but I think these patches can help, if the lame implementation I did isn't ok, at least the tests can be used :-).

