### PR TITLE
Resolve undefined variables for optional Enumerable arguments

### DIFF
--- a/src/g_i_repository/info/function_info.cr
+++ b/src/g_i_repository/info/function_info.cr
@@ -115,14 +115,9 @@ module GIRepository
 
         collection_args.each do |arg|
           if arg.nilable?
-            line def_if(arg.name) { |b|
-              b.line b.assign "__#{arg.name}", arg.for_wrapper_pass(builder, libname)
-              size = b.call("size", receiver: "__#{arg.name}_ary")
-              b.line b.assign "n_#{arg.name}", b.ternary(builder.var("__#{arg.name}_ary"), size, b.literal(0))
-            }.else { |b|
-              b.line b.assign "__#{arg.name}", arg.for_wrapper_pass(builder, libname)
-              b.line b.assign "n_#{arg.name}", b.literal(0)
-            }
+            line assign "__#{arg.name}", arg.for_wrapper_pass(builder, libname)
+            size = call("size", receiver: "__#{arg.name}_ary")
+            line assign "n_#{arg.name}", ternary("__#{arg.name}_ary", size, literal(0))
           else
             line assign "__#{arg.name}", arg.for_wrapper_pass(builder, libname)
             line assign "n_#{arg.name}", call("size", receiver: "__#{arg.name}_ary")

--- a/src/g_i_repository/info/function_info.cr
+++ b/src/g_i_repository/info/function_info.cr
@@ -114,15 +114,17 @@ module GIRepository
         end
 
         collection_args.each do |arg|
-          line assign "__#{arg.name}", arg.for_wrapper_pass(builder, libname)
           if arg.nilable?
             line def_if(arg.name) { |b|
+              b.line b.assign "__#{arg.name}", arg.for_wrapper_pass(builder, libname)
               size = b.call("size", receiver: "__#{arg.name}_ary")
               b.line b.assign "n_#{arg.name}", b.ternary(builder.var("__#{arg.name}_ary"), size, b.literal(0))
             }.else { |b|
+              b.line b.assign "__#{arg.name}", arg.for_wrapper_pass(builder, libname)
               b.line b.assign "n_#{arg.name}", b.literal(0)
             }
           else
+            line assign "__#{arg.name}", arg.for_wrapper_pass(builder, libname)
             line assign "n_#{arg.name}", call("size", receiver: "__#{arg.name}_ary")
           end
         end

--- a/src/g_i_repository/info/function_info.cr
+++ b/src/g_i_repository/info/function_info.cr
@@ -114,15 +114,15 @@ module GIRepository
         end
 
         collection_args.each do |arg|
+          line assign "__#{arg.name}", arg.for_wrapper_pass(builder, libname)
           if arg.nilable?
             line def_if(arg.name) { |b|
-              b.line b.assign "__#{arg.name}", arg.for_wrapper_pass(builder, libname)
-              b.line b.assign "n_#{arg.name}", b.call("size", receiver: "__#{arg.name}_ary")
+              size = b.call("size", receiver: "__#{arg.name}_ary")
+              b.line b.assign "n_#{arg.name}", b.ternary(builder.var("__#{arg.name}_ary"), size, b.literal(0))
             }.else { |b|
               b.line b.assign "n_#{arg.name}", b.literal(0)
             }
           else
-            line assign "__#{arg.name}", arg.for_wrapper_pass(builder, libname)
             line assign "n_#{arg.name}", call("size", receiver: "__#{arg.name}_ary")
           end
         end


### PR DESCRIPTION
Closes #96

Since the children of the `def_if` also check for the validity of the arguments, removing the `def_if` entirely and just setting acceptable default values for a single path correctly handles optional arguments.

```crystal
require "gobject"
require_gobject "Arrow"

b = Arrow::Buffer.new(Bytes.new(10))
arr = Arrow::Tensor.new(Arrow::UInt8DataType.new, b, [10], [1], nil)
puts arr

# <Arrow::Tensor:0x1053b7d80>
```